### PR TITLE
Sort list of package dependencies

### DIFF
--- a/pallet.el
+++ b/pallet.el
@@ -186,6 +186,7 @@
   (let ((depends-list '()))
     (dolist (package package-list)
       (push (format "(depends-on \"%s\")" package) depends-list))
+    (sort depends-list #'string<)
     (mapconcat 'identity depends-list "\n")))
 
 (defun pt/write-file (file contents)


### PR DESCRIPTION
This prevents trivial differences in carton files on different machines,
and makes merging easier when keeping the file under version control.
