### PR TITLE
Use the public github URL for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "el.mk"]
 	path = el.mk
-	url = git@github.com:rdallasgray/el.mk.git
+	url = https://github.com/rdallasgray/el.mk.git


### PR DESCRIPTION
The old version was preventing access to people not using ssh on github
