### PR TITLE
Removes the need to use the Makefile while hacking on the project

### DIFF
--- a/src/pallet.el
+++ b/src/pallet.el
@@ -29,7 +29,7 @@
 
 ;;; Commentary:
 ;;
-@COMMENTARY
+;@COMMENTARY
 ;;
 ;;; Code:
 


### PR DESCRIPTION
This change needs the corresponding one-character change in el.mk.
This is crucial to avoid losing some time while working in `pallet.el`.
We should not have to use `make` in order to test every change.
If `@COMMENTARY` is not in an actual comment it is impossible to load `src/pallet.el` which slows down any workflow.
