### PR TITLE
Ensure that tests work with 'make test' out-of-the-box

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,4 @@ servant-start:
 	@cask exec servant start --path "test" &
 
 test: servant-start
-	@cask exec ert-runner && cask exec servant stop --path "test"
+	@cask exec ert-runner; status=$$?; cask exec servant stop --path "test"; exit $$status

--- a/test/packages/package-one-0.0.1.el
+++ b/test/packages/package-one-0.0.1.el
@@ -1,7 +1,0 @@
-;;; package-one.el --- a test package
-
-;; Version: 0.0.1
-
-(provide 'package-one)
-
-;;; package-one.el ends here

--- a/test/packages/package-two-0.0.1.el
+++ b/test/packages/package-two-0.0.1.el
@@ -1,7 +1,0 @@
-;;; package-two.el --- a test package
-
-;; Version: 0.0.1
-
-(provide 'package-two)
-
-;;; package-two.el ends here

--- a/test/packages/package-two-0.0.2.el
+++ b/test/packages/package-two-0.0.2.el
@@ -1,7 +1,0 @@
-;;; package-two.el --- a test package
-
-;; Version: 0.0.2
-
-(provide 'package-two)
-
-;;; package-two.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -35,6 +35,7 @@
 
 (defun test/add-servant-package (package)
   "Add PACKAGE to the servant repository"
+  (ignore-errors (make-directory test/package-path))
   (f-write (test/package-text package)
            'utf-8
            (f-expand (format "%s.el"


### PR DESCRIPTION
* Create the test/servant/packages directory when necessary
* Remove redundant test/packages directory
* Stop servant even if tests fail

Closes #41.